### PR TITLE
edit_protoype_controller#create

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -15,7 +15,7 @@ class PrototypesController < ApplicationController
     if @prototype.save
       redirect_to :root, notice: 'New prototype was successfully created'
     else
-      redirect_to ({ action: new }), alert: 'YNew prototype was unsuccessfully created'
+      render :new, alert: 'YNew prototype was unsuccessfully created'
      end
   end
 


### PR DESCRIPTION
#WHAT
PrototypeControllerのcreateアクションの修正
#WHY
保存できない時にエラーがでるため。